### PR TITLE
Fix/term namespace

### DIFF
--- a/lib/pact_elixir/term.ex
+++ b/lib/pact_elixir/term.ex
@@ -1,7 +1,8 @@
-defmodule Term do
+defmodule PactElixir.Term do
+
   defstruct [:generate, :regex]
 
-  def get_my_map(%Term{} = term) do
+  def get_my_map(%PactElixir.Term{} = term) do
     %{
       json_class: "Pact::Term",
       data: %{

--- a/lib/pact_elixir/termdetector.ex
+++ b/lib/pact_elixir/termdetector.ex
@@ -1,4 +1,6 @@
 defmodule PactElixir.TermDetector do
+  alias PactElixir.Term, as: Term
+
   def recursively_update_terms(%Term{} = to_update) do
     to_update_new = Term.get_my_map(to_update)
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PactElixir.MixProject do
   def project do
     [
       app: :pact_elixir,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.6",
       name: "PactElixir",
       start_permanent: Mix.env() == :prod,

--- a/test/term_test.exs
+++ b/test/term_test.exs
@@ -1,4 +1,5 @@
 defmodule PactElixir.TermTest do
+  alias PactElixir.Term, as: Term
   use ExUnit.Case
 
   test "default constructor with arguments" do

--- a/test/termdetector_test.exs
+++ b/test/termdetector_test.exs
@@ -1,4 +1,5 @@
 defmodule PactElixir.TermDetectorTest do
+  alias PactElixir.Term, as: Term
   use ExUnit.Case
 
   test "detect and convert empty Term in map to desired format" do


### PR DESCRIPTION
Corrects namespace for Term module to PactElixir.Term
Otherwise, Term is not found if pact_elixir used as dependency.

Bumping version for this small change.